### PR TITLE
Add code folding #region support in coffeescript

### DIFF
--- a/extensions/coffeescript/language-configuration.json
+++ b/extensions/coffeescript/language-configuration.json
@@ -23,6 +23,10 @@
 		["'", "'"]
 	],
 	"folding": {
-		"offSide": true
+		"offSide": true,
+		"markers": {
+			"start": "^\\s*#region\\b",
+			"end": "^\\s*#endregion\\b"
+		}
 	}
 }


### PR DESCRIPTION
Add support for VS Code fold regions in CoffeeScript using #region and #endregion markers. 